### PR TITLE
Fix loop delay extension

### DIFF
--- a/apnewslivebot.py
+++ b/apnewslivebot.py
@@ -193,6 +193,16 @@ def format_message(topic: str, title: str, url: str, ts_iso: str) -> str:
     return f"📰 *{topic}* | {safe_title}\n{ts_iso}\n{url}"
 
 
+# ---------- Delay calculation ----------
+def calculate_delay(current_interval: float, elapsed: float) -> float:
+    """Return remaining delay before next cycle.
+
+    Ensures the loop does not wait extra time if processing exceeded the
+    configured interval.
+    """
+    return max(0, current_interval - elapsed)
+
+
 # ---------- Main loop ----------
 def main():
     load_sent()
@@ -248,7 +258,10 @@ def main():
             logging.error(f"Cycle error: {e}")
 
         elapsed = time.time() - loop_start
-        time.sleep(max(5, current_interval - elapsed))
+        # Sleep only for the remaining time left in the interval. If the loop
+        # took longer than the interval, start the next iteration immediately
+        # instead of adding extra delay.
+        time.sleep(calculate_delay(current_interval, elapsed))
 
 
 if __name__ == "__main__":

--- a/tests/test_delay.py
+++ b/tests/test_delay.py
@@ -1,0 +1,12 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test")
+os.environ.setdefault("TELEGRAM_CHANNEL_ID", "test")
+import apnewslivebot
+
+
+def test_calculate_delay_no_extension():
+    # If the cycle exceeded the interval, delay should be zero
+    assert apnewslivebot.calculate_delay(10, 12) == 0
+    # Otherwise delay is interval minus elapsed
+    assert apnewslivebot.calculate_delay(10, 4) == 6


### PR DESCRIPTION
## Summary
- calculate remaining delay with `calculate_delay`
- avoid extending loop interval after long cycles
- add test covering delay logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886880cae0c8320a40cb7180d1699f2