### PR TITLE
Fix relative URL handling in parse_live_page

### DIFF
--- a/apnewslivebot.py
+++ b/apnewslivebot.py
@@ -154,7 +154,10 @@ def parse_live_page(topic_name: str, url: str):
     for post in posts:
         pid = post.get("@id") or post.get("url") or f"{post.get('headline')}_{post.get('datePublished')}"
         title = post.get("headline", "").strip()
-        permalink = post.get("url") or url
+        post_url = post.get("url")
+        if post_url and not post_url.startswith("http"):
+            post_url = normalize_url(post_url)
+        permalink = post_url or url
         ts_iso = post.get("datePublished") or post.get("dateModified")
         if pid and pid not in sent_post_ids:
             new_items.append((pid, title, permalink, ts_iso))

--- a/tests/test_parse_live_page.py
+++ b/tests/test_parse_live_page.py
@@ -52,6 +52,30 @@ HTML_SNIPPET = f"""
 </html>
 """
 
+REL_LD_JSON = {
+    "@context": "https://schema.org",
+    "@type": "LiveBlogPosting",
+    "blogPosts": [
+        {
+            "@id": "r1",
+            "headline": "Relative",
+            "url": "/article/rel1",
+            "datePublished": "2024-01-01T12:00:00Z",
+        }
+    ],
+}
+
+REL_SNIPPET = f"""
+<html>
+<head>
+<script type='application/ld+json'>
+{json.dumps(REL_LD_JSON)}
+</script>
+</head>
+<body></body>
+</html>
+"""
+
 
 def test_parse_live_page_chronological(monkeypatch):
     def mock_fetch(url, timeout=15, retries=3, backoff=3):
@@ -64,3 +88,16 @@ def test_parse_live_page_chronological(monkeypatch):
     titles = [p[1] for p in posts]
 
     assert titles == ["First", "Second", "Third"]
+
+
+def test_parse_live_page_relative_urls(monkeypatch):
+    def mock_fetch(url, timeout=15, retries=3, backoff=3):
+        return REL_SNIPPET
+
+    monkeypatch.setattr(apnewslivebot, "fetch", mock_fetch)
+    apnewslivebot.sent_post_ids.clear()
+
+    posts = apnewslivebot.parse_live_page("topic", "https://example.com/live")
+
+    assert len(posts) == 1
+    assert posts[0][2] == apnewslivebot.HOMEPAGE_URL + "/article/rel1"


### PR DESCRIPTION
## Summary
- handle relative URLs in `parse_live_page`
- test chronological ordering and relative URL normalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868801314c8320ba0319e1fdbca2ee