### PR TITLE
Escape more markdown characters

### DIFF
--- a/apnewslivebot.py
+++ b/apnewslivebot.py
@@ -189,6 +189,11 @@ def format_message(topic: str, title: str, url: str, ts_iso: str) -> str:
         .replace("*", "\\*")
         .replace("[", "\\[")
         .replace("`", "\\`")
+        .replace("(", "\\(")
+        .replace(")", "\\)")
+        .replace("~", "\\~")
+        .replace(">", "\\>")
+        .replace("#", "\\#")
     )
     return f"📰 *{topic}* | {safe_title}\n{ts_iso}\n{url}"
 

--- a/tests/test_format_message.py
+++ b/tests/test_format_message.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test")
+os.environ.setdefault("TELEGRAM_CHANNEL_ID", "test")
+
+import apnewslivebot
+
+
+def test_format_message_escapes_additional_chars():
+    title = "chars ( ) ~ > #"
+    msg = apnewslivebot.format_message(
+        "Topic", title, "https://example.com", "2024-01-01T00:00:00Z"
+    )
+
+    assert "\\(" in msg
+    assert "\\)" in msg
+    assert "\\~" in msg
+    assert "\\>" in msg
+    assert "\\#" in msg
+


### PR DESCRIPTION
## Summary
- escape `(`, `)`, `~`, `>` and `#` in formatted Telegram messages
- test escaping of the additional characters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886881324ac8320a4f9a84d9ab5bb79