### PR TITLE
Prevent duplicate posts across topics

### DIFF
--- a/apnewslivebot.py
+++ b/apnewslivebot.py
@@ -233,16 +233,14 @@ def main():
                 new_posts.sort(key=lambda t: t[3] or "")
 
                 for pid, title, link, ts_iso in new_posts:
-                    if pid in sent_post_ids:
+                    if pid in sent_post_ids or link in sent_links:
                         continue
                     msg = format_message(topic_name, title, link, ts_iso)
                     send_telegram_message(msg)
                     sent_post_ids.add(pid)
-                    sent_links.add(link)  # still track URLs to avoid x‑topic dupes
-                    logging.info(f"Sent: {title}")
-
-                if new_posts:
+                    sent_links.add(link)
                     save_sent()
+                    logging.info(f"Sent: {title}")
 
         except Exception as e:
             logging.error(f"Cycle error: {e}")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test")
+os.environ.setdefault("TELEGRAM_CHANNEL_ID", "test")
+
+import apnewslivebot
+
+
+def test_main_skips_duplicate_links(monkeypatch):
+    messages = []
+
+    def mock_get_live_topics():
+        return {"A": "urlA", "B": "urlB"}
+
+    def mock_parse_live_page(topic_name, url):
+        return [(topic_name, "Title", "https://example.com/shared", "2024-01-01T00:00:00Z")]
+
+    def mock_send(msg):
+        messages.append(msg)
+
+    def stop_sleep(seconds):
+        raise SystemExit
+
+    monkeypatch.setattr(apnewslivebot, "get_live_topics", mock_get_live_topics)
+    monkeypatch.setattr(apnewslivebot, "parse_live_page", mock_parse_live_page)
+    monkeypatch.setattr(apnewslivebot, "send_telegram_message", mock_send)
+    monkeypatch.setattr(apnewslivebot.time, "sleep", stop_sleep)
+    monkeypatch.setattr(apnewslivebot, "save_sent", lambda: None)
+
+    apnewslivebot.sent_links.clear()
+    apnewslivebot.sent_post_ids.clear()
+
+    try:
+        apnewslivebot.main()
+    except SystemExit:
+        pass
+
+    # first message is the start notification
+    assert len(messages) == 2
+    article_messages = [m for m in messages if "https://example.com/shared" in m]
+    assert len(article_messages) == 1


### PR DESCRIPTION
## Summary
- avoid sending telegram messages when the link was already processed
- save links immediately after sending
- test that duplicate links across topics are skipped

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886882c63ec8320b54674e40ebd46ad