### PR TITLE
Improve title and link handling

### DIFF
--- a/tests/test_format_message.py
+++ b/tests/test_format_message.py
@@ -28,3 +28,22 @@ def test_format_message_plain_text():
     expected = f"{title}\n\n📰 Topic - {expected_date} CET\n\nhttps://example.com"
     assert msg == expected
 
+
+def test_format_message_strips_html():
+    title = "<b>AP poll tracker: Trump's disapproval</b>"
+    msg = apnewslivebot.format_message(
+        "Topic",
+        title,
+        "https://example.com",
+        "2024-01-01T00:00:00Z",
+    )
+
+    expected_date = (
+        datetime(2024, 1, 1, tzinfo=timezone.utc)
+        .astimezone(ZoneInfo("Europe/Paris"))
+        .strftime("%m/%d/%y %H:%M")
+    )
+    expected_title = "AP poll tracker: Trump's disapproval"
+    expected = f"{expected_title}\n\n📰 Topic - {expected_date} CET\n\nhttps://example.com"
+    assert msg == expected
+

--- a/tests/test_parse_live_page.py
+++ b/tests/test_parse_live_page.py
@@ -123,6 +123,20 @@ COPY_SNIPPET = f"""
 </html>
 """
 
+# Copy links using relative paths
+COPY_REL_SNIPPET = f"""
+<html>
+<head>
+<script type='application/ld+json'>
+{json.dumps(LD_JSON)}
+</script>
+</head>
+<body>
+  <article id='p1'><bsp-copy-link data-link='/live#p1'></bsp-copy-link></article>
+</body>
+</html>
+"""
+
 
 def test_parse_live_page_chronological(monkeypatch):
     def mock_fetch(url, timeout=15, retries=3, backoff=3):
@@ -179,3 +193,15 @@ def test_parse_live_page_copy_links(monkeypatch):
         "https://example.com/live#p2",
         "https://example.com/live#p3",
     ]
+
+
+def test_parse_live_page_copy_links_relative(monkeypatch):
+    def mock_fetch(url, timeout=15, retries=3, backoff=3):
+        return COPY_REL_SNIPPET
+
+    monkeypatch.setattr(apnewslivebot, "fetch", mock_fetch)
+    apnewslivebot.sent_post_ids.clear()
+
+    posts = apnewslivebot.parse_live_page("topic", "https://example.com/live")
+    assert len(posts) == 3
+    assert posts[0][2] == "https://apnews.com/live#p1"


### PR DESCRIPTION
## Summary
- sanitize HTML tags in news titles before posting
- normalize permalink URLs from copy links
- use copy link URLs for Telegram posts
- add regression tests for HTML titles and relative copy links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a5b4358388320a65db12f9d52cbed