### PR TITLE
Use unique anchor links in Telegram messages

### DIFF
--- a/apnewslivebot.py
+++ b/apnewslivebot.py
@@ -220,11 +220,13 @@ def parse_live_page(topic_name: str, url: str):
 
     new_items = []
     for post in posts:
-        pid = post.get("@id") or post.get("url") or f"{post.get('headline')}_{post.get('datePublished', post.get('dateModified', ''))}"
+        pid = (
+            post.get("@id")
+            or post.get("url")
+            or f"{post.get('headline')}_{post.get('datePublished', post.get('dateModified', ''))}"
+        )
         title = post.get("headline", "").strip() or post.get("name", "").strip()
-        permalink = post.get("@id") or post.get("url") or url
-        if isinstance(permalink, str) and permalink.startswith("/"):
-            permalink = normalize_url(permalink)
+        permalink = url  # start with the live page URL
         ts_iso = post.get("datePublished") or post.get("dateModified") or datetime.now(timezone.utc).isoformat()
 
         if pid:
@@ -233,6 +235,8 @@ def parse_live_page(topic_name: str, url: str):
                 permalink = copy_links[pid_fragment]
             elif pid in copy_links:
                 permalink = copy_links[pid]
+            else:
+                permalink = f"{url}#{pid_fragment}"
 
         if pid and pid not in sent_post_ids:
             new_items.append((pid, title, permalink, ts_iso))

--- a/tests/test_parse_live_page.py
+++ b/tests/test_parse_live_page.py
@@ -161,8 +161,8 @@ def test_parse_live_page_relative_urls(monkeypatch):
     posts = apnewslivebot.parse_live_page("topic", "https://example.com/live")
 
     assert len(posts) == 1
-    # permalink now prefers the @id field
-    assert posts[0][2] == "r1"
+    # permalink now uses the live page with an anchor to the post id
+    assert posts[0][2] == "https://example.com/live#r1"
 
 
 def test_parse_live_page_blogPost_key(monkeypatch):


### PR DESCRIPTION
## Summary
- build post-specific URLs using the post id when parsing live pages
- update tests to expect anchored links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c141b2cfc83209e8b4ea958e0b7d6