### PR TITLE
Use cloudscraper for HTTP fetch with 403 handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ requests==2.32.4
 aiohttp==3.9.5
 beautifulsoup4==4.12.3
 upstash-redis==1.4.0
+cloudscraper==1.2.71
 pytest==8.2.1


### PR DESCRIPTION
## Summary
- Replace basic requests fetching with a cloudscraper-based session that mimics a real browser.
- Retry and recreate the scraper on 403 responses to work around Cloudflare challenges.
- Add cloudscraper to project requirements.

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892aa55acb083208c10782a262eb5c5