### PR TITLE
feat(dedupe): RapidFuzz token_set_ratio guard (92)

### DIFF
--- a/dedupe.py
+++ b/dedupe.py
@@ -1,0 +1,26 @@
+import re
+import string
+from html import unescape
+from typing import Iterable
+
+from rapidfuzz import fuzz
+
+
+def canonize(text: str) -> str:
+    """Normalize text for duplicate detection."""
+    text = unescape(text)
+    text = re.sub(r"<[^>]+>", " ", text)  # strip HTML tags
+    text = text.lower()
+    text = re.sub(rf"[{re.escape(string.punctuation)}]", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def is_near_duplicate(candidate: str, recent_list: Iterable[str], threshold: int = 92) -> bool:
+    """Return True if candidate is a near-duplicate of any text in recent_list."""
+    cand = canonize(candidate)
+    for recent in recent_list:
+        score = fuzz.token_set_ratio(cand, canonize(recent))
+        if score >= threshold:
+            return True
+    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ beautifulsoup4==4.12.3
 upstash-redis==1.4.0
 cloudscraper==1.2.71
 pytest==8.2.1
+
+rapidfuzz==3.9.3

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from dedupe import canonize, is_near_duplicate
+
+
+def test_punctuation_only_edit_blocked():
+    recent = ["Breaking news about economy"]
+    candidate = "Breaking news about economy!!!"
+    assert canonize(candidate) == canonize(recent[0])
+    assert is_near_duplicate(candidate, recent)
+
+
+def test_genuinely_new_post_passes():
+    recent = ["Breaking news about economy"]
+    candidate = "Weather updates for the weekend"
+    assert canonize(candidate) != canonize(recent[0])
+    assert not is_near_duplicate(candidate, recent)


### PR DESCRIPTION
## Summary
- add dedupe utilities to canonize text and block near duplicates using RapidFuzz token_set_ratio
- cover near-duplicate logic with tests
- include rapidfuzz in requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde1a5520083209e6b2c473cd2021b