### PR TITLE
feat(hashtags_llm): LLM hashtags (2–6) + topic-only deterministic fallback

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .apnewslivebot import *

--- a/hashtags_llm.py
+++ b/hashtags_llm.py
@@ -1,0 +1,67 @@
+import json
+import re
+from typing import List
+
+from openai import OpenAI
+
+HASHTAG_RE = re.compile(r"^#[A-Za-z0-9]{2,40}$")
+
+
+def llm_hashtags(title: str, topic: str, when: str, url: str) -> List[str]:
+    prompt = (
+        f"title: {title}\n"
+        f"topic: {topic}\n"
+        f"when: {when}\n"
+        f"url: {url}"
+    )
+    client = OpenAI()
+    resp = client.chat.completions.create(
+        model="gpt-4o-mini",
+        temperature=0.2,
+        messages=[{"role": "user", "content": prompt}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "return_hashtags",
+                    "description": "Return 2-6 hashtags for the post",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "hashtags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "pattern": "^#[A-Za-z0-9]{2,40}$",
+                                },
+                                "minItems": 2,
+                                "maxItems": 6,
+                            }
+                        },
+                        "required": ["hashtags"],
+                    },
+                },
+                "strict": True,
+            }
+        ],
+        tool_choice={"type": "function", "function": {"name": "return_hashtags"}},
+    )
+    try:
+        tool_args = resp.choices[0].message.tool_calls[0].function.arguments
+        data = json.loads(tool_args)
+        tags = data.get("hashtags")
+        if (
+            isinstance(tags, list)
+            and 2 <= len(tags) <= 6
+            and all(isinstance(t, str) and HASHTAG_RE.fullmatch(t) for t in tags)
+        ):
+            seen = set()
+            unique = []
+            for t in tags:
+                if t not in seen:
+                    unique.append(t)
+                    seen.add(t)
+            return unique
+    except Exception:
+        return []
+    return []

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ cloudscraper==1.2.71
 pytest==8.2.1
 
 rapidfuzz==3.9.3
+openai>=1.0.0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,6 +28,7 @@ def test_main_skips_duplicate_links(monkeypatch):
     monkeypatch.setattr(apnewslivebot, "send_telegram_message", mock_send)
     monkeypatch.setattr(apnewslivebot.time, "sleep", stop_sleep)
     monkeypatch.setattr(apnewslivebot, "save_sent", lambda: None)
+    monkeypatch.setattr(apnewslivebot, "llm_hashtags", lambda *a, **k: [])
 
     apnewslivebot.sent_links.clear()
     apnewslivebot.sent_post_ids.clear()

--- a/tests/test_topic_fallback.py
+++ b/tests/test_topic_fallback.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from apnewslivebot import topic_only_hashtags
+
+def test_top25(): assert topic_only_hashtags("AP Top 25")==["#Top25"]
+
+def test_live_strip(): assert topic_only_hashtags("LIVE: Israel-Gaza updates")==["#IsraelGazaUpdates"]
+
+def test_punct(): assert topic_only_hashtags("AP   Top—25!! ")==["#Top25"]


### PR DESCRIPTION
## Summary
- use OpenAI chat completions with a strict function tool to generate 2–6 hashtags
- add deterministic topic-only fallback for hashtag generation
- integrate LLM hashtags into main loop and add fallback tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bde5e6968883208fd3b2c0c242682f