### PR TITLE
Fix hset staging of pending posts

### DIFF
--- a/store.py
+++ b/store.py
@@ -63,7 +63,7 @@ def stage_pending(story_key: str, body: str, hashtags: List[str]) -> None:
     try:
         redis.hset(
             k(f"post:{story_key}"),
-            {"body": body, "hashtags": json.dumps(hashtags)},
+            values={"body": body, "hashtags": json.dumps(hashtags)},
         )
         redis.lpush(k("recent_bodies"), body)
         redis.ltrim(k("recent_bodies"), 0, 4)


### PR DESCRIPTION
## Summary
- use `hset(..., values=...)` to correctly save pending posts in Redis

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdf457ac18832099aba211a3dc2afa