### PR TITLE
Ensure logs are visible on Render

### DIFF
--- a/apnewslivebot.py
+++ b/apnewslivebot.py
@@ -2,6 +2,7 @@ import os
 import time
 import json
 import logging
+import sys
 import re
 import signal
 import unicodedata
@@ -77,6 +78,7 @@ HOMEPAGE_URL = "https://apnews.com"
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
+    stream=sys.stdout,
 )
 
 # ---------- Optional Upstash Redis ----------


### PR DESCRIPTION
## Summary
- route Python logging output to stdout so Render captures it

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdfff1dd548320984e1c191811c4ef